### PR TITLE
fix(gsea): fix margin too large error

### DIFF
--- a/R/gseaEnrichment.R
+++ b/R/gseaEnrichment.R
@@ -129,7 +129,7 @@ gseaEnrichment <- function(hostName, outputDirectory, projectName, geneRankList,
 
 #' @importFrom svglite svglite
 plotEnrichmentPlot <- function(title, outputDir, fileName, format = "png", runningSums, ranks, scores, peakIndex) {
-    tryCatch(
+    try(
         {
             if (format == "png") {
                 output_file <- file.path(outputDir, paste0(sanitizeFileName(fileName), ".png"))
@@ -170,11 +170,6 @@ plotEnrichmentPlot <- function(title, outputDir, fileName, format = "png", runni
             dev.off()
             return(output_file)
         },
-        error = function(error_message) {
-            warning(error_message)
-        },
-        warning = function(error_message) {
-            warning(error_message)
-        }
+        silent = TRUE
     )
 }

--- a/R/gseaEnrichment.R
+++ b/R/gseaEnrichment.R
@@ -129,39 +129,52 @@ gseaEnrichment <- function(hostName, outputDirectory, projectName, geneRankList,
 
 #' @importFrom svglite svglite
 plotEnrichmentPlot <- function(title, outputDir, fileName, format = "png", runningSums, ranks, scores, peakIndex) {
-    if (format == "png") {
-        png(file.path(outputDir, paste0(sanitizeFileName(fileName), ".png")), bg = "transparent", width = 2000, height = 2000)
-        cex <- list(main = 5, axis = 2.5, lab = 3.2)
-    } else if (format == "svg") {
-        svglite(file.path(outputDir, paste0(sanitizeFileName(fileName), ".svg")), bg = "transparent", width = 7, height = 7)
-        cex <- list(main = 1.5, axis = 0.6, lab = 0.8)
-        # svg seems to have a problem with long title (figure margins too large)
-        if (!is.na(nchar(title))) {
-            if (nchar(title) > 80) {
-                title <- paste0(substr(title, 1, 80), "...")
+    tryCatch(
+        {
+            if (format == "png") {
+                output_file <- file.path(outputDir, paste0(sanitizeFileName(fileName), ".png"))
+                png(output_file, bg = "transparent", width = 2000, height = 2000)
+                cex <- list(main = 5, axis = 2.5, lab = 3.2)
+            } else if (format == "svg") {
+                output_file <- file.path(outputDir, paste0(sanitizeFileName(fileName), ".svg"))
+                svglite(output_file, bg = "transparent", width = 7, height = 7)
+                cex <- list(main = 1.5, axis = 0.6, lab = 0.8)
+                # svg seems to have a problem with long title (figure margins too large)
+                if (!is.na(nchar(title))) {
+                    if (nchar(title) > 80) {
+                        title <- paste0(substr(title, 1, 80), "...")
+                    }
+                }
             }
+            wrappedTitle <- strwrap(paste0("Enrichment plot: ", title), 60)
+            plot.new()
+            par(fig = c(0, 1, 0.5, 1), mar = c(0, 6, 6 * length(wrappedTitle), 2), cex.axis = cex$axis, cex.main = cex$main, cex.lab = cex$lab, lwd = 2, new = TRUE)
+            plot(1:length(runningSums), runningSums,
+                type = "l", main = paste(wrappedTitle, collapse = "\n"),
+                xlab = "", ylab = "Enrichment Score", xaxt = "n", lwd = 3
+            )
+            abline(v = peakIndex, lty = 3)
+            par(fig = c(0, 1, 0.35, 0.5), mar = c(0, 6, 0, 2), new = TRUE)
+            plot(ranks, rep(1, length(ranks)),
+                type = "h",
+                xlim = c(1, length(scores)), ylim = c(0, 1), axes = FALSE, ann = FALSE
+            )
+            par(fig = c(0, 1, 0, 0.35), mar = c(6, 6, 0, 2), cex.axis = cex$axis, cex.lab = cex$lab, new = TRUE)
+            # use polygon to greatly reduce file size of SVG
+            plot(1:length(scores), scores,
+                type = "n",
+                ylab = "Ranked list metric", xlab = "Rank in Ordered Dataset"
+            )
+            polygon(c(1, 1:length(scores), length(scores)), c(0, scores, 0), col = "black")
+            abline(v = peakIndex, lty = 3)
+            dev.off()
+            return(output_file)
+        },
+        error = function(error_message) {
+            warning(error_message)
+        },
+        warning = function(error_message) {
+            warning(error_message)
         }
-    }
-    wrappedTitle <- strwrap(paste0("Enrichment plot: ", title), 60)
-    plot.new()
-    par(fig = c(0, 1, 0.5, 1), mar = c(0, 6, 6 * length(wrappedTitle), 2), cex.axis = cex$axis, cex.main = cex$main, cex.lab = cex$lab, lwd = 2, new = TRUE)
-    plot(1:length(runningSums), runningSums,
-        type = "l", main = paste(wrappedTitle, collapse = "\n"),
-        xlab = "", ylab = "Enrichment Score", xaxt = "n", lwd = 3
     )
-    abline(v = peakIndex, lty = 3)
-    par(fig = c(0, 1, 0.35, 0.5), mar = c(0, 6, 0, 2), new = TRUE)
-    plot(ranks, rep(1, length(ranks)),
-        type = "h",
-        xlim = c(1, length(scores)), ylim = c(0, 1), axes = FALSE, ann = FALSE
-    )
-    par(fig = c(0, 1, 0, 0.35), mar = c(6, 6, 0, 2), cex.axis = cex$axis, cex.lab = cex$lab, new = TRUE)
-    # use polygon to greatly reduce file size of SVG
-    plot(1:length(scores), scores,
-        type = "n",
-        ylab = "Ranked list metric", xlab = "Rank in Ordered Dataset"
-    )
-    polygon(c(1, 1:length(scores), length(scores)), c(0, scores, 0), col = "black")
-    abline(v = peakIndex, lty = 3)
-    dev.off()
 }

--- a/R/multiGseaEnrichment.R
+++ b/R/multiGseaEnrichment.R
@@ -208,7 +208,7 @@ multiGseaEnrichment <- function(hostName = NULL, outputDirectory = NULL, project
 
 #' @importFrom svglite svglite
 plotEnrichmentPlot <- function(title, outputDir, fileName, format = "png", runningSums, ranks, scores, peakIndex) {
-    tryCatch(
+    try(
         {
             if (format == "png") {
                 output_file <- file.path(outputDir, paste0(sanitizeFileName(fileName), ".png"))
@@ -249,11 +249,6 @@ plotEnrichmentPlot <- function(title, outputDir, fileName, format = "png", runni
             dev.off()
             return(output_file)
         },
-        error = function(error_message) {
-            warning(error_message)
-        },
-        warning = function(error_message) {
-            warning(error_message)
-        }
+        silent = TRUE
     )
 }

--- a/R/multiGseaEnrichment.R
+++ b/R/multiGseaEnrichment.R
@@ -208,42 +208,52 @@ multiGseaEnrichment <- function(hostName = NULL, outputDirectory = NULL, project
 
 #' @importFrom svglite svglite
 plotEnrichmentPlot <- function(title, outputDir, fileName, format = "png", runningSums, ranks, scores, peakIndex) {
-    if (format == "png") {
-        output_file <- file.path(outputDir, paste0(sanitizeFileName(fileName), ".png"))
-        png(output_file, bg = "transparent", width = 2000, height = 2000)
-        cex <- list(main = 5, axis = 2.5, lab = 3.2)
-    } else if (format == "svg") {
-        output_file <- file.path(outputDir, paste0(sanitizeFileName(fileName), ".svg"))
-        svglite(output_file, bg = "transparent", width = 7, height = 7)
-        cex <- list(main = 1.5, axis = 0.6, lab = 0.8)
-        # svg seems to have a problem with long title (figure margins too large)
-        if (!is.na(nchar(title))) {
-            if (nchar(title) > 80) {
-                title <- paste0(substr(title, 1, 80), "...")
+    tryCatch(
+        {
+            if (format == "png") {
+                output_file <- file.path(outputDir, paste0(sanitizeFileName(fileName), ".png"))
+                png(output_file, bg = "transparent", width = 2000, height = 2000)
+                cex <- list(main = 5, axis = 2.5, lab = 3.2)
+            } else if (format == "svg") {
+                output_file <- file.path(outputDir, paste0(sanitizeFileName(fileName), ".svg"))
+                svglite(output_file, bg = "transparent", width = 7, height = 7)
+                cex <- list(main = 1.5, axis = 0.6, lab = 0.8)
+                # svg seems to have a problem with long title (figure margins too large)
+                if (!is.na(nchar(title))) {
+                    if (nchar(title) > 80) {
+                        title <- paste0(substr(title, 1, 80), "...")
+                    }
+                }
             }
+            wrappedTitle <- strwrap(paste0("Enrichment plot: ", title), 60)
+            plot.new()
+            par(fig = c(0, 1, 0.5, 1), mar = c(0, 6, 6 * length(wrappedTitle), 2), cex.axis = cex$axis, cex.main = cex$main, cex.lab = cex$lab, lwd = 2, new = TRUE)
+            plot(1:length(runningSums), runningSums,
+                type = "l", main = paste(wrappedTitle, collapse = "\n"),
+                xlab = "", ylab = "Enrichment Score", xaxt = "n", lwd = 3
+            )
+            abline(v = peakIndex, lty = 3)
+            par(fig = c(0, 1, 0.35, 0.5), mar = c(0, 6, 0, 2), new = TRUE)
+            plot(ranks, rep(1, length(ranks)),
+                type = "h",
+                xlim = c(1, length(scores)), ylim = c(0, 1), axes = FALSE, ann = FALSE
+            )
+            par(fig = c(0, 1, 0, 0.35), mar = c(6, 6, 0, 2), cex.axis = cex$axis, cex.lab = cex$lab, new = TRUE)
+            # use polygon to greatly reduce file size of SVG
+            plot(1:length(scores), scores,
+                type = "n",
+                ylab = "Ranked list metric", xlab = "Rank in Ordered Dataset"
+            )
+            polygon(c(1, 1:length(scores), length(scores)), c(0, scores, 0), col = "black")
+            abline(v = peakIndex, lty = 3)
+            dev.off()
+            return(output_file)
+        },
+        error = function(error_message) {
+            warning(error_message)
+        },
+        warning = function(error_message) {
+            warning(error_message)
         }
-    }
-    wrappedTitle <- strwrap(paste0("Enrichment plot: ", title), 60)
-    plot.new()
-    par(fig = c(0, 1, 0.5, 1), mar = c(0, 6, 6 * length(wrappedTitle), 2), cex.axis = cex$axis, cex.main = cex$main, cex.lab = cex$lab, lwd = 2, new = TRUE)
-    plot(1:length(runningSums), runningSums,
-        type = "l", main = paste(wrappedTitle, collapse = "\n"),
-        xlab = "", ylab = "Enrichment Score", xaxt = "n", lwd = 3
     )
-    abline(v = peakIndex, lty = 3)
-    par(fig = c(0, 1, 0.35, 0.5), mar = c(0, 6, 0, 2), new = TRUE)
-    plot(ranks, rep(1, length(ranks)),
-        type = "h",
-        xlim = c(1, length(scores)), ylim = c(0, 1), axes = FALSE, ann = FALSE
-    )
-    par(fig = c(0, 1, 0, 0.35), mar = c(6, 6, 0, 2), cex.axis = cex$axis, cex.lab = cex$lab, new = TRUE)
-    # use polygon to greatly reduce file size of SVG
-    plot(1:length(scores), scores,
-        type = "n",
-        ylab = "Ranked list metric", xlab = "Rank in Ordered Dataset"
-    )
-    polygon(c(1, 1:length(scores), length(scores)), c(0, scores, 0), col = "black")
-    abline(v = peakIndex, lty = 3)
-    dev.off()
-    return(output_file)
 }


### PR DESCRIPTION
If the analyte set title for the GSEA plot is too long, it can create an error `figure margin too large`. This was previously addressed for SVG files by shortening the title. HMDB features many pathways with long names that seemed to still break the SVG output, or it was able to create this problem for the PNG output. Because the GSEA plot is not an absolutely necessary output for the analysis, it should not create an error, but instead it should display a warning.

## Fix applied

The `plotEnrichmentPlot` function content is surrounded in a `try` to prevent errors in this function from stopping the analysis.

## Further steps

- [ ] Add a warning message if this error occurs
- [ ] Add more intervention to stop this error from occurring