### PR TITLE
Stop naming a meta method that no longer exists

### DIFF
--- a/R/multiOraEnrichment.R
+++ b/R/multiOraEnrichment.R
@@ -77,7 +77,10 @@ multiOraEnrichment <- function(interestGene, referenceGene, geneSet, minNum = 10
     combined_size[["size"]][[i]] <- length(unique(genes_in_list))
   }
   combined_size <- data.frame(geneSet = unlist(combined_size[["geneSet"]]), size = unlist(combined_size[["size"]]), stringsAsFactors = FALSE)
-  rust_result <- rust_multiomics_ora(modified_geneset, genes, interestGene, referenceGene, "fisher")
+  # "stouffer", not "fisher": the meta-p this returns is discarded a few lines below and
+  # recomputed with poolr::stouffer, but naming a method that no longer exists upstream
+  # would be misleading (bzhanglab/webgestalt_rust#30).
+  rust_result <- rust_multiomics_ora(modified_geneset, genes, interestGene, referenceGene, "stouffer")
   rust_result_df <- lapply(rust_result, function(x) {
     data.frame(
       FDR = p.adjust(x$p, method = fdrMethod), pValue = x$p, expect = x$expect,

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -178,14 +178,15 @@ pub fn rust_multiomics_ora(
     };
     let parts = big_part_vec.as_list().unwrap();
     let reference_lists = reference.as_list().unwrap();
-    let method = match method.as_str().unwrap() {
-        "fisher" => webgestalt_lib::methods::multilist::MultiListMethod::Meta(
-            webgestalt_lib::methods::multilist::MetaAnalysisMethod::Fisher,
-        ),
-        _ => webgestalt_lib::methods::multilist::MultiListMethod::Meta(
-            webgestalt_lib::methods::multilist::MetaAnalysisMethod::Stouffer,
-        ),
-    };
+    // Stouffer regardless of what the caller names: it is the only meta method the library
+    // offers, and the only one this package has ever used. The Fisher arm that stood here
+    // selected an implementation that returned a chi-square density rather than a p-value
+    // (bzhanglab/webgestalt_rust#30) and was removed upstream. Its result was discarded in
+    // any case — the meta-p reaching users is computed in R by poolr::stouffer.
+    let _ = method;
+    let method = webgestalt_lib::methods::multilist::MultiListMethod::Meta(
+        webgestalt_lib::methods::multilist::MetaAnalysisMethod::Stouffer,
+    );
     let interest_vec = interest.as_list().unwrap();
     let big_set_vec = sets.as_list().unwrap();
     let mut jobs: Vec<ORAJob> = Vec::new();
@@ -337,8 +338,9 @@ fn gsea_rust(
 /// @param parts A list of the analytse in the analyte sets
 /// @param analytes A vector of analytes names in the GSEA list
 /// @param ranks A vector of ranks for the analytes in the GSEA list
-/// @param method_modifier method modifier for the multiomics method ("fisher" or "stouffer" if
-/// meta-analysis, "mean", "max", or "rank" if other combination method)
+/// @param method_modifier method modifier for the multiomics method (ignored for
+/// meta-analysis, which is always Stouffer; "mean", "max", or "rank" if other combination
+/// method)
 /// @param combo_method method for combining analyte sets (meta, mean, or max)
 /// @return List of lists of the results of GSEA
 /// @author John Elizarraras
@@ -363,14 +365,11 @@ pub fn rust_multiomics_gsea(
         ..Default::default()
     };
     let method = if combo_method.as_str().unwrap() == "meta" {
-        match method_modifier.as_str().unwrap() {
-            "fisher" => webgestalt_lib::methods::multilist::MultiListMethod::Meta(
-                webgestalt_lib::methods::multilist::MetaAnalysisMethod::Fisher,
-            ),
-            _ => webgestalt_lib::methods::multilist::MultiListMethod::Meta(
-                webgestalt_lib::methods::multilist::MetaAnalysisMethod::Stouffer,
-            ),
-        }
+        // Stouffer regardless: see the note in rust_multiomics_ora above. Fisher was removed
+        // upstream (bzhanglab/webgestalt_rust#30).
+        webgestalt_lib::methods::multilist::MultiListMethod::Meta(
+            webgestalt_lib::methods::multilist::MetaAnalysisMethod::Stouffer,
+        )
     } else {
         let norm = match method_modifier.as_str().unwrap() {
             "mean" => webgestalt_lib::methods::multilist::NormalizationMethod::MeanValue,


### PR DESCRIPTION
Companion to [webgestalt_rust#36](https://github.com/bzhanglab/webgestalt_rust/pull/36), which removes `MetaAnalysisMethod::Fisher` — its implementation returned a chi-square density rather than a p-value ([#30](https://github.com/bzhanglab/webgestalt_rust/issues/30)).

**Merge this first.** It drops the package's dependency on that variant, so the next re-vendor after #36 lands compiles cleanly.

## No behaviour change

`multiOraEnrichment.R` passed `"fisher"` to `rust_multiomics_ora`, and then discarded the meta-p it got back and recomputed it with `poolr::stouffer` a few lines later. `multiswGsea.R` does the same for GSEA. So the Fisher path ran on every multi-omics ORA analysis and its output never reached a user — no published result is affected.

It now asks for `"stouffer"`, which is what the R layer was doing anyway.

## Changes

- `src/rust/src/lib.rs` — both `rust_multiomics_ora` and `rust_multiomics_gsea` selected Fisher on the string `"fisher"` and Stouffer on anything else; both now select Stouffer unconditionally. The second site is easy to miss: it sits inside the `combo_method == "meta"` branch.
- `R/multiOraEnrichment.R` — passes `"stouffer"`.
- The `method_modifier` roxygen no longer offers `"fisher"` as a choice.

The vendored `webgestalt_lib` still has the variant, so this compiles as-is; it simply stops naming it.